### PR TITLE
Style : Modal Slide 컴포넌트 UI 제작

### DIFF
--- a/src/components/Modal/ModalSlide.jsx
+++ b/src/components/Modal/ModalSlide.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { ModalContainerDiv, ModalUl, ModalBtn } from './ModalSlideStyle';
+
+export default function ModalSlide() {
+  return (
+    <ModalContainerDiv>
+      <ModalUl>
+        <li>
+          <ModalBtn>삭제</ModalBtn>
+        </li>
+        <li>
+          <ModalBtn>수정</ModalBtn>
+        </li>
+      </ModalUl>
+    </ModalContainerDiv>
+  );
+}

--- a/src/components/Modal/ModalSlideStyle.jsx
+++ b/src/components/Modal/ModalSlideStyle.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import styled from 'styled-components';
+
+export const ModalContainerDiv = styled.div`
+  position: fixed;
+  width: 100%;
+  margin: 0 auto;
+  bottom: 0px;
+  box-shadow: 0 1px 20px 0 rgba(0, 0, 0, 0.1);
+  border-radius: 10px 10px 0 0;
+`;
+
+export const ModalUl = styled.ul`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  width: 100%;
+  padding: 36px 0 10px;
+  &::before {
+    content: '';
+    position: absolute;
+    width: 50px;
+    height: 4px;
+    top: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-radius: 5px;
+    background-color: var(--sub-grey-C4);
+  }
+  & > li {
+    list-style: none;
+  }
+`;
+
+export const ModalBtn = styled.button`
+  width: 100%;
+  padding: 14px 26px;
+  border: none;
+  background-color: inherit;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 18px;
+  text-align: left;
+`;


### PR DESCRIPTION
### 무엇을 위한 PR인가요?
- [X] 스타일 : Modal Slide 컴포넌트 UI 제작


### 전달사항
- 모달 컴포넌트 중 더보기 버튼을 누르면 아래에서 뜨는 슬라이드 창 UI를 제작했습니다.
- 스타일 컴포넌트 파일을 분리했습니다.
- 컴포넌트명을 새 컨벤션에 맞게 작성했습니다.


### 변경사항 및 이유
- 이유 : 없습니다.


### 작업 내역
- 작업 내역 :
ModalSlide.jsx
ModalSlideStyle.jsx


### 기대 결과 및 스크린샷
 <img width="500" alt="스크린샷 2022-12-13 오전 2 33 22" src="https://user-images.githubusercontent.com/109451148/207114695-9ff9fede-231d-4708-bc0a-005f21830bcc.png">


### Issue Number
close : #7
