### PR TITLE
Style : Nav 컴포넌트 UI 제작

### DIFF
--- a/src/components/Nav/Nav.jsx
+++ b/src/components/Nav/Nav.jsx
@@ -1,5 +1,47 @@
 import React from 'react';
+import NavItem from './NavItem';
+import iconHome from '../../assets/img/icon-home.png';
+import iconHomeFill from '../../assets/img/icon-home-fill.png';
+import iconMessage from '../../assets/img/icon-message-circle-1.png';
+import iconMessageFill from '../../assets/img/icon-message-circle-fill.png';
+import iconEdit from '../../assets/img/icon-edit.png';
+import iconUser from '../../assets/img/icon-user.png';
+import iconUserFill from '../../assets/img/icon-user-fill.png';
+import { ContainerNav, NavUl } from './NavStyle';
 
 export default function Nav() {
-  return <div>Nav</div>;
+  const IconHome = {
+    default: iconHome,
+    fill: iconHomeFill,
+  };
+  const IconMessage = {
+    default: iconMessage,
+    fill: iconMessageFill,
+  };
+  const IconEdit = {
+    default: iconEdit,
+  };
+  const IconUser = {
+    default: iconUser,
+    fill: iconUserFill,
+  };
+
+  return (
+    <ContainerNav>
+      <NavUl>
+        <li>
+          <NavItem link="/" icon={IconHome} name="홈" />
+        </li>
+        <li>
+          <NavItem link="/chat" icon={IconMessage} name="채팅" />
+        </li>
+        <li>
+          <NavItem link="/post/1" icon={IconEdit} name="게시물 작성" />
+        </li>
+        <li>
+          <NavItem link="/user_profile/1" icon={IconUser} name="프로필" />
+        </li>
+      </NavUl>
+    </ContainerNav>
+  );
 }

--- a/src/components/Nav/NavItem.jsx
+++ b/src/components/Nav/NavItem.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { NavLink, StyledImg } from './NavItemStyle';
+
+export default function NavItem({ link, icon, name }) {
+  console.log(icon);
+  return (
+    <NavLink to={link}>
+      <StyledImg src={icon.default} alt="" />
+      <p>{name}</p>
+    </NavLink>
+  );
+}

--- a/src/components/Nav/NavItemStyle.jsx
+++ b/src/components/Nav/NavItemStyle.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+import { Link } from 'react-router-dom';
+
+export const NavLink = styled(Link)`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  line-height: 1.4rem;
+  list-style: none;
+  gap: 4px;
+  p {
+    color: var(--main-grey-76);
+  }
+`;
+
+export const StyledImg = styled.img`
+  width: 24px;
+  height: 24px;
+`;

--- a/src/components/Nav/NavStyle.jsx
+++ b/src/components/Nav/NavStyle.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+export const ContainerNav = styled.nav`
+  width: 100%;
+  background-color: var(--white);
+  border-top: 1px solid var(--sub-grey-C4);
+  position: fixed;
+  bottom: 0;
+`;
+
+export const NavUl = styled.ul`
+  display: flex;
+  justify-content: space-evenly;
+  padding: 14px 6px 6px 6px;
+`;


### PR DESCRIPTION
### 무엇을 위한 PR인가요?
- [x] 스타일 : 하단의 탭메뉴바 Nav 컴포넌트 UI 제작


### 전달사항
- 마켓 하단의 탭메뉴바 Nav 컴포넌트 UI를 제작했습니다.
- 창 크기에 맞추어 유연하게 늘어납니다.
- 스타일 컴포넌트 파일을 분리했습니다.
Nav.jsx : 메뉴바 
NavItem.jsx : 메뉴바 안의 아이템(홈/채팅/게시글작성/프로필)


### 변경사항 및 이유
- 이유 : 없습니다.


### 작업 내역
- 작업 내역 : 
Nav.jsx
NavStyle.jsx
NavItem.jsx
NavItemStyle.jsx


### 기대 결과 및 스크린샷
<img width="500" alt="스크린샷 2022-12-13 오전 2 45 33" src="https://user-images.githubusercontent.com/109451148/207117826-5dfb2983-02e0-4841-8c77-446878e92f8d.png">
* 추후 각 버튼을 누르면 1.해당 화면으로 이동하는 기능 2.아이콘의 색이 채워지는 기능이 필요합니다.


### Issue Number
close : #5
