### PR TITLE
Style : ProfileImgAccountStyle component 제작

### DIFF
--- a/src/components/ProfileImgAccount/ProfileImgAccount.jsx
+++ b/src/components/ProfileImgAccount/ProfileImgAccount.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ProfileAccount from '../ProfileAccount/ProfileAccount';
+import ProfileComponentImg from '../../assets/img/basic-profile.png';
+import {
+  ProfileImgContainerStyle,
+  ProfileComponentImgStyle,
+} from './ProfileImgAccountStyle';
+
+export default function ProfileImgAccount({ width, marginbottom }) {
+  return (
+    <ProfileImgContainerStyle>
+      <ProfileComponentImgStyle src={ProfileComponentImg} width={width} />
+      <ProfileAccount size="1.4rem" marginbottom={marginbottom} />
+    </ProfileImgContainerStyle>
+  );
+}

--- a/src/components/ProfileImgAccount/ProfileImgAccountStyle.jsx
+++ b/src/components/ProfileImgAccount/ProfileImgAccountStyle.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import styled from 'styled-components';
+
+export const ProfileImgContainerStyle = styled.div`
+  display: flex;
+  align-items: center;
+`;
+export const ProfileComponentImgStyle = styled.img`
+  width: ${(props) => props.width};
+`;


### PR DESCRIPTION
### 무엇을 위한 PR인가요?
- [x] 스타일 : 프로필 사진과 유저 이름이 함께 묶인 컴포넌트 제작

### 전달사항
- 프로필 이미지와 유저 이름이 함께 묶인 컴포넌트입니다.
- 프로필 이미지 사이즈는 width로 지정해주세요. ex)`<ProfileImgAccount width="40px" />`
- 피그마에서 확인되는 해당 컴포넌트의 두 텍스트 사이 상하 여백 옵션은 6px과 2px입니다. 기본 셋팅은 6px이며 2px의 여백을 원하실 경우 marginbottom으로 지정해주세요. 작성하지 않으면 6px로 적용됩니다. ex) `<ProfileImgAccount width="40px" marginbottom="2px" />`

### 변경사항 및 이유
- 이유 : 재활용되는 부분이 많아 만들어두신 컴포넌트를 묶어 하나의 컴포넌트로 추가 제작했습니다.


### 작업 내역
- 작업 내역 : ProfileImgAccount.jsx, ProfileImgAccountStyle.jsx


### 스크린샷
<img width="163" alt="스크린샷 2022-12-13 오후 6 25 18" src="https://user-images.githubusercontent.com/94048689/207278918-f01f7ba0-9a1e-4878-b517-93685a9d1a2f.png">


### Issue Number
close : #
