### PR TITLE
Modify : Input.jsx에서 style 파일 분리

### DIFF
--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -1,17 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
-
-const InputStyle = styled.input`
-  width: 322px;
-  height: 33px;
-  border: transparent;
-  border-bottom: 1px solid #dbdbdb;
-  margin-bottom: 16px;
-  outline: none;
-  &:focus {
-    border-bottom: 2px solid var(--point-green);
-  }
-`;
+import InputStyle from './InputStyle';
 
 export default function Input({ label, type }) {
   return (

--- a/src/components/Input/InputStyle.jsx
+++ b/src/components/Input/InputStyle.jsx
@@ -1,5 +1,15 @@
-import React from 'react';
+import styled from 'styled-components';
 
-export default function InputStyle() {
-  return <div>InputStyle</div>;
-}
+const InputStyle = styled.input`
+  width: 322px;
+  height: 33px;
+  border: transparent;
+  border-bottom: 1px solid #dbdbdb;
+  margin-bottom: 16px;
+  outline: none;
+  &:focus {
+    border-bottom: 2px solid var(--point-green);
+  }
+`;
+
+export default InputStyle;


### PR DESCRIPTION
### 무엇을 위한 PR인가요?
- [x] 리팩토링 : Input.jsx에서 style 파일 분리


### 변경사항 및 이유
- 이유 : 파일 컨벤션을 지키기 위해 Input.jsx에서 Style파일을 분리했습니다.


### 작업 내역
- 작업 내역 : Input.jsx, InputStyle.jsx

