### PR TITLE
Style/profile component modify

### DIFF
--- a/src/components/Chat/ChatListItem/ChatListItem.jsx
+++ b/src/components/Chat/ChatListItem/ChatListItem.jsx
@@ -5,13 +5,14 @@ import {
   DateSpan,
 } from './ChatListItemStyle';
 
-export default function ChatListItem({ username, usertext }) {
+export default function ChatListItem({ username, usertext, src }) {
   return (
     <ChatListContanierStyle>
       <ProfileImgAccountStyle
         width="42px"
         namemarginbottom="4px"
         margin="0 0 0 16px"
+        src={src}
         username={username}
         usertext={usertext}
       />

--- a/src/components/Profile/Profile.jsx
+++ b/src/components/Profile/Profile.jsx
@@ -11,6 +11,7 @@ import ProfileImg from '../ProfileImg/ProfileImg';
 import ChatIcon from '../../components/ChatIcon/ChatIcon';
 import Button from '../../components/Button/Button';
 import ShareIcon from '../../components/ShareIcon/ShareIcon';
+import DefaultProfileImg from '../../assets/img/basic-profile.png';
 
 export default function Profile({
   username,
@@ -24,7 +25,7 @@ export default function Profile({
     <ContDivStyle>
       <FollowStyle>
         <FollowersCount count="3000" follow="follower" />
-        <ProfileImg />
+        <ProfileImg width="110px" height="110px" src={DefaultProfileImg} />
         <FollowersCount count="1200" follow="followings" />
       </FollowStyle>
       <ProfileAccount

--- a/src/components/ProfileImg/ProfileImg.jsx
+++ b/src/components/ProfileImg/ProfileImg.jsx
@@ -1,17 +1,14 @@
 import React from 'react';
-import basicProfile from '../../assets/img/basic-profile-50.png';
-import {
-  InputFileFormStyle,
-  UploadProfileLabelStyle,
-  UploadProfileInputStyle,
-} from './ProfileImgStyle';
+import DefaultProfileImg from '../../assets/img/basic-profile.png';
+import ProfileImgStyle from './ProfileImgStyle';
 
-export default function ProfileImg() {
+export default function ProfileImg({ src, width, height }) {
   return (
-    <InputFileFormStyle>
-      <img src={basicProfile} alt="프로필 이미지" width="110" height="110" />
-      <UploadProfileLabelStyle htmlFor="uploadProfile"></UploadProfileLabelStyle>
-      <UploadProfileInputStyle type="file" id="uploadProfile" />
-    </InputFileFormStyle>
+    <ProfileImgStyle
+      src={src}
+      alt="프로필 이미지"
+      width={width}
+      height={height}
+    />
   );
 }

--- a/src/components/ProfileImg/ProfileImgStyle.jsx
+++ b/src/components/ProfileImg/ProfileImgStyle.jsx
@@ -1,21 +1,9 @@
 import styled from 'styled-components';
-import uploadFile from '../../assets/img/upload-file.png';
 
-export const InputFileFormStyle = styled.div`
-  height: 110px;
-  margin: 30px auto;
-  position: relative;
-  width: 110px;
+const ProfileImgStyle = styled.img`
+  border-radius: 50%;
+  width: ${(props) => props.width};
+  height: ${(props) => props.height};
 `;
-export const UploadProfileLabelStyle = styled.label`
-  right: 0px;
-  bottom: 0px;
-  position: absolute;
-  background: url(${uploadFile}) no-repeat 50%/36px;
-  height: 36px;
-  width: 36px;
-  cursor: pointer;
-`;
-export const UploadProfileInputStyle = styled.input`
-  display: none;
-`;
+
+export default ProfileImgStyle;

--- a/src/components/ProfileImgAccount/ProfileImgAccount.jsx
+++ b/src/components/ProfileImgAccount/ProfileImgAccount.jsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import ProfileAccount from '../ProfileAccount/ProfileAccount';
-import ProfileComponentImg from '../../assets/img/basic-profile.png';
-import {
-  ProfileImgContainerStyle,
-  ProfileComponentImgStyle,
-} from './ProfileImgAccountStyle';
+import DefaultProfileImg from '../../assets/img/basic-profile.png';
+import { ProfileImgContainerStyle } from './ProfileImgAccountStyle';
+import ProfileImg from '../ProfileImg/ProfileImg';
 
 export default function ProfileImgAccount({
   width,
+  height,
   margin,
   namemarginbottom,
   username,
@@ -16,7 +15,7 @@ export default function ProfileImgAccount({
 }) {
   return (
     <ProfileImgContainerStyle className={className}>
-      <ProfileComponentImgStyle src={ProfileComponentImg} width={width} />
+      <ProfileImg src={DefaultProfileImg} width={width} height={height} />
       <ProfileAccount
         size="1.4rem"
         margin={margin}

--- a/src/components/UploadProfileImg/UploadProfileImg.jsx
+++ b/src/components/UploadProfileImg/UploadProfileImg.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import basicProfile from '../../assets/img/basic-profile-50.png';
+import {
+  InputFileFormStyle,
+  UploadProfileLabelStyle,
+  UploadProfileInputStyle,
+} from './UploadProfileImgStyle';
+
+export default function UploadProfileImg() {
+  return (
+    <InputFileFormStyle>
+      <img src={basicProfile} alt="프로필 이미지" width="110" height="110" />
+      <UploadProfileLabelStyle htmlFor="uploadProfile"></UploadProfileLabelStyle>
+      <UploadProfileInputStyle type="file" id="uploadProfile" />
+    </InputFileFormStyle>
+  );
+}

--- a/src/components/UploadProfileImg/UploadProfileImgStyle.jsx
+++ b/src/components/UploadProfileImg/UploadProfileImgStyle.jsx
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+import uploadFile from '../../assets/img/upload-file.png';
+
+export const InputFileFormStyle = styled.div`
+  height: 110px;
+  margin: 30px auto;
+  position: relative;
+  width: 110px;
+`;
+export const UploadProfileLabelStyle = styled.label`
+  right: 0px;
+  bottom: 0px;
+  position: absolute;
+  background: url(${uploadFile}) no-repeat 50%/36px;
+  height: 36px;
+  width: 36px;
+  cursor: pointer;
+`;
+export const UploadProfileInputStyle = styled.input`
+  display: none;
+`;

--- a/src/pages/Main/Profile/MyProfile/ProfileEdit/ProfileEdit.jsx
+++ b/src/pages/Main/Profile/MyProfile/ProfileEdit/ProfileEdit.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ProfileImg from '../../../../../components/ProfileImg/ProfileImg';
 import Input from '../../../../../components/Input/Input';
 import Header from '../../../../../components/Header/Header';
+import InputFormStyle from '../ProfileEdit/ProfileEditStyle';
 
 export default function ProfileEdit() {
   return (

--- a/src/pages/Main/Profile/MyProfile/ProfileEdit/ProfileEdit.jsx
+++ b/src/pages/Main/Profile/MyProfile/ProfileEdit/ProfileEdit.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ProfileImg from '../../../../../components/ProfileImg/ProfileImg';
+import UploadProfileImg from '../../../../../components/UploadProfileImg/UploadProfileImg';
 import Input from '../../../../../components/Input/Input';
 import Header from '../../../../../components/Header/Header';
 import InputFormStyle from '../ProfileEdit/ProfileEditStyle';
@@ -11,7 +11,7 @@ export default function ProfileEdit() {
         저장
       </Header>
       <InputFormStyle>
-        <ProfileImg />
+        <UploadProfileImg />
         <Input
           label="사용자 이름"
           type="text"


### PR DESCRIPTION
### 무엇을 위한 PR인가요?
- [x] 스타일 : Profile component 수정


### 전달사항
- 프로필 이미지를 불러오는 데이터에 맞게 넣어줄 수 있도록 src={src} prop을 추가했습니다. 사용하는 페이지에서 `data.author.image`처럼 불러와 프로필 이미지를 출력해줄 수 있습니다.
- 하나의 컴포넌트로 다양한 프로필 이미지 사이즈에 대응할 수 있도록 width와 height를 prop로 추가했습니다.
- 현재 수정사항에서 영향을 주는 컴포넌트들의 props만 수정된 상태입니다. 혹시 작업하시는 페이지에서 프로필 이미지가 사라졌다면 사이즈 설정이 누락되어 그런것이니 작업하시면서 추가해주시면 감사드리겠습니다.


### 변경사항 및 이유
- 업로드용 프로필 이미지 컴포넌트는 UploadProfileImg로 변경했습니다.
- ProfileEdit.jsx 에서의 Import 에러를 수정했습니다. 


### 작업 내역
- 작업 내역 : Files changed를 참고해주세요


### 기대 결과
- 프로필 이미지 컴포넌트를 다양한 곳에서 재활용할 수 있습니다.


### Issue Number
close : #86 
