### PR TITLE
Feat : Post 수정 페이지 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import ProfileEdit from './pages/Main/Profile/MyProfile/ProfileEdit/ProfileEdit'
 import ProductUpload from './pages/Main/Profile/MyProfile/Product/ProductUpload/ProductUpload';
 import ProductEdit from './pages/Main/Profile/MyProfile/Product/ProductEdit/ProductEdit';
 import Post from './pages/Main/Post/Post';
+import PostEdit from './pages/Main/Post/PostEdit/PostEdit';
 import ChatRoom from './pages/Main/Chat/ChatRoom/ChatRoom';
 
 const router = createBrowserRouter([
@@ -71,6 +72,10 @@ const router = createBrowserRouter([
   {
     path: '/post/:id',
     element: <Post />,
+  },
+  {
+    path: '/post/:id/edit',
+    element: <PostEdit />,
   },
   {
     path: '/chat/:id',

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -18,24 +18,21 @@ export default function Header({
   children,
   onClick,
   go,
+  id,
 }) {
+  console.log(id);
   const navigate = useNavigate();
   const path = window.location.pathname;
   if (
-    path === '/my_profile' ||
+    path.includes('/my_profile') ||
     path.includes('/user_profile/') ||
-    path.includes('post/') ||
+    path === `/post/${id}` ||
     path === '/chat'
   )
     return (
       <HeaderStyle>
-        <button>
-          <img
-            src={iconArrowLeft}
-            alt="뒤로가기"
-            height="22"
-            onClick={() => navigate(-1)}
-          />
+        <button onClick={() => navigate(-1)}>
+          <img src={iconArrowLeft} alt="뒤로가기" height="22" />
         </button>
         <button>
           <img src={iconMore} alt="더보기" height="22" />
@@ -45,13 +42,8 @@ export default function Header({
   else if (path !== '/chat' && path !== '/chat/' && path.includes('/chat/'))
     return (
       <HeaderStyle>
-        <button>
-          <img
-            src={iconArrowLeft}
-            alt="뒤로가기"
-            height="22"
-            onClick={() => navigate(-1)}
-          />
+        <button onClick={() => navigate(-1)}>
+          <img src={iconArrowLeft} alt="뒤로가기" height="22" />
         </button>
         <TopChatTitleStyle>{children}</TopChatTitleStyle>
         <button>
@@ -71,13 +63,8 @@ export default function Header({
   else if (path === '/search')
     return (
       <HeaderStyle>
-        <button>
-          <img
-            src={iconArrowLeft}
-            alt="뒤로가기"
-            height="22"
-            onClick={() => navigate(-1)}
-          />
+        <button onClick={() => navigate(-1)}>
+          <img src={iconArrowLeft} alt="뒤로가기" height="22" />
         </button>
         <TopSearchInputStyle
           type="text"
@@ -88,18 +75,14 @@ export default function Header({
   else if (
     path === '/profile_edit' ||
     path === '/post_upload' ||
+    path === `/post/${id}/edit` ||
     path === '/product_upload' ||
     path.includes('/product/')
   )
     return (
       <HeaderStyle>
-        <button>
-          <img
-            src={iconArrowLeft}
-            alt="뒤로가기"
-            height="22"
-            onClick={() => navigate(-1)}
-          />
+        <button onClick={() => navigate(-1)}>
+          <img src={iconArrowLeft} alt="뒤로가기" height="22" />
         </button>
         <Button
           type="submit"

--- a/src/pages/Main/Post/PostEdit/PostEdit.jsx
+++ b/src/pages/Main/Post/PostEdit/PostEdit.jsx
@@ -1,5 +1,238 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import { authAtom, accountAtom } from '../../../../_state/auth';
+import API from '../../../../API';
+import {
+  PageWrapStyle,
+  ConWrapStyle,
+  MyProfileImg,
+  PostTextAreaStyle,
+  Form,
+  BtnWrapStyle,
+  ImgWrapStyle,
+  ImgItemWrapStyle,
+  ImgPreview,
+  ImgDeleteBtn,
+} from '../PostUpload/PostUploadStyle';
+import Header from '../../../../components/Header/Header';
+import UploadFileBtn from '../../../../components/Button/UploadFileBtn/UploadFileBtn';
 
-export default function PostEdit() {
-  return <div>PostEdit</div>;
+function PostUpload() {
+  const auth = useRecoilValue(authAtom);
+  const account = useRecoilValue(accountAtom);
+  const { id } = useParams();
+  const [text, setText] = useState('');
+  const [isActive, setIsActive] = useState(false);
+  const [selectedImg, setSelectedImg] = useState([]);
+  const [imgUrl, setImgUrl] = useState('');
+  const [profileImg, setProfileImg] = useState('');
+  const postData = {
+    post: {
+      content: text,
+      image: selectedImg.join(','),
+    },
+  };
+  const formData = new FormData();
+
+  // 프로필 이미지 불러오기
+  useEffect(() => {
+    const GetMyProfile = async () => {
+      try {
+        const res = await API.get('/user/myinfo', {
+          headers: {
+            Authorization: `Bearer ${auth}`,
+          },
+        });
+        console.log(res);
+        setProfileImg(res.data.user.image);
+      } catch (err) {
+        if (err.response) {
+          // 응답코드 2xx가 아닌 경우
+          console.log(err.response.data);
+          console.log(err.response.status);
+          console.log(err.response.headers);
+        } else {
+          console.log(`Error: ${err.message}`);
+        }
+      }
+    };
+    GetMyProfile();
+  }, []);
+
+  // 기존 게시글 불러오기
+  useEffect(() => {
+    const GetPostData = async () => {
+      try {
+        const res = await API.get(`/post/${id}`, {
+          headers: {
+            Authorization: `Bearer ${auth}`,
+            'Content-type': 'application/json',
+          },
+        });
+        console.log(res);
+        console.log(res.data.post);
+        const postDetail = res.data.post;
+        setText(postDetail.content);
+        if (postDetail.image) {
+          setImgUrl(postDetail.image.split(','));
+        }
+      } catch (err) {
+        if (err.response) {
+          // 응답코드 2xx가 아닌 경우
+          console.log(err.response.data);
+          console.log(err.response.status);
+          console.log(err.response.headers);
+        } else {
+          console.log(`Error: ${err.message}`);
+        }
+      }
+    };
+    GetPostData();
+  }, [auth, id]);
+
+  // 텍스트를 입력하거나 이미지 파일이 있으면 버튼 활성화
+  useEffect(() => {
+    if (text || imgUrl) {
+      setIsActive(true);
+    } else {
+      setIsActive(false);
+    }
+  }, [text, imgUrl]);
+
+  // input에 입력한 값 알아내서 저장
+  const OnChangeHandler = (e) => {
+    setText(e.target.value);
+  };
+
+  // 게시글 수정 PUT
+  const EditUploadHandler = async () => {
+    try {
+      if (!text && selectedImg.length === 0) {
+        alert('내용 또는 이미지를 입력해주세요.');
+      }
+      const res = await API.put(
+        `/post/63a9510917ae666581226227`,
+        JSON.stringify(postData),
+        {
+          headers: {
+            Authorization: `Bearer ${auth}`,
+            'Content-type': 'application/json',
+          },
+          data: postData,
+        }
+      );
+      console.log(res);
+    } catch (err) {
+      if (err.response) {
+        // 응답코드 2xx가 아닌 경우
+        console.log(err.response.data);
+        console.log(err.response.status);
+        console.log(err.response.headers);
+      } else {
+        console.log(`Error: ${err.message}`);
+      }
+    }
+  };
+
+  // 이미지 업로드
+  const ChangeFileHandler = async (e) => {
+    const file = e.target.files[0];
+    // console.log(file);
+    setSelectedImg((prevState) => [...prevState, file.name]);
+    formData.append('image', file);
+    if (imgUrl >= 3) {
+      alert('3개 이하의 파일을 업로드 하세요.');
+      return;
+    }
+    try {
+      const res = await API.post('/image/uploadfile', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      });
+      // 이미지 미리보기
+      const previewImg = () => {
+        if (file === undefined) {
+          return;
+        }
+        const fileReader = new FileReader();
+        fileReader.readAsDataURL(file);
+        // 클릭할 때 마다 file input의 value를 초기화 하지 않으면 버그가 발생할 수 있다 (사진을 올리고 지우고 다시 같은 사진을 올리면 그 값이 남아있다?)
+        e.target.value = '';
+        fileReader.onload = () => {
+          setImgUrl((ImgUrl) => [...ImgUrl, fileReader.result]);
+        };
+      };
+      // 포스트된 이미지 보기
+      if (res.data.message === '이미지 파일만 업로드가 가능합니다.') {
+        alert(
+          '이미지 파일만 업로드가 가능합니다. 올바른 형식의 파일을 넣어주세요. (*.jpg, *.gif, *.png, *.jpeg, *.bmp, *.tif, *.heic)'
+        );
+      } else {
+        // console.log(res.data.filename);
+        setSelectedImg([
+          ...selectedImg,
+          `https://mandarin.api.weniv.co.kr/${res.data.filename}`,
+        ]);
+        previewImg(file);
+      }
+      console.log(res);
+    } catch (err) {
+      if (err.response) {
+        // 응답코드 2xx가 아닌 경우
+        console.log(err.response.data);
+        console.log(err.response.status);
+        console.log(err.response.headers);
+      } else {
+        console.log(`Error: ${err.message}`);
+      }
+    }
+  };
+
+  // 미리보기 이미지 삭제
+  const ImgDeleteHandler = (targetIndex) => {
+    // img.index가 파라미터로 일치하지 않는 원소만 추출해서 새로운 배열을 만든다
+    // targetIndex는 삭제할 대상의 index이고 img.index가 targetIndex와 같은 것을 삭제한다
+    const imgArr = selectedImg.filter((img) => img.index !== targetIndex);
+    setSelectedImg([...imgArr]);
+  };
+
+  return (
+    <PageWrapStyle>
+      <Header
+        size="ms"
+        variant={isActive ? '' : 'disabled'}
+        go={isActive ? `/my_profile/${account}` : ''}
+        onClick={EditUploadHandler}
+      >
+        업로드
+      </Header>
+      <ConWrapStyle>
+        <MyProfileImg src={profileImg} alt="" />
+        <Form>
+          <PostTextAreaStyle
+            type="text"
+            placeholder="게시글 입력하기"
+            onChange={OnChangeHandler}
+            value={text}
+          ></PostTextAreaStyle>
+          <ImgWrapStyle>
+            {imgUrl &&
+              imgUrl.map((img, index) => (
+                <ImgItemWrapStyle key={index} id={index}>
+                  <ImgPreview src={img} alt="이미지 미리보기" />
+                  <ImgDeleteBtn onClick={() => ImgDeleteHandler(index)} />
+                </ImgItemWrapStyle>
+              ))}
+          </ImgWrapStyle>
+          <BtnWrapStyle>
+            <UploadFileBtn onChange={ChangeFileHandler} />
+          </BtnWrapStyle>
+        </Form>
+      </ConWrapStyle>
+    </PageWrapStyle>
+  );
 }
+
+export default PostUpload;

--- a/src/pages/Main/Post/PostEdit/PostEdit.jsx
+++ b/src/pages/Main/Post/PostEdit/PostEdit.jsx
@@ -204,6 +204,7 @@ function PostUpload() {
         size="ms"
         variant={isActive ? '' : 'disabled'}
         go={isActive ? `/my_profile/${account}` : ''}
+        id={id}
         onClick={EditUploadHandler}
       >
         업로드


### PR DESCRIPTION
### 무엇을 위한 PR인가요?
- [x] 기능 추가 : post 수정 페이지를 구현했습니다. (/post/:id/edit)

### 전달사항
- App.jsx에 post edit 페이지 라우터를 추가했습니다.
- 프로필 이미지를 불러옵니다.
- 텍스트를 수정해서 재업로드할 수 있습니다.
- 텍스트가 없는 글에 이미지를 추가해서 재업로드할 수 있습니다.
-  post와 post edit 페이지에 id props를 내려서 각각 필요한 header를 불러올 수 있습니다.
(post 페이지의 header에 id props 추가한 커밋 : https://github.com/One-Hundred-Trials/Good-Harvest-Market/commit/dcfd1dadfd0ce2dadc9707938fe945ea63074fda)
-  추후 해결할 부분 : 1. 기존 이미지를 삭제하는 경우 업로드해보면 실제로 삭제는 되지만 미리보기 이미지에서는 삭제되지 않고 있습니다. 2. 기존 이미지 그대로 재업로드시 이미지가 사라집니다.

### 변경사항 및 이유
- 이유 : 없습니다.


### 작업 내역
- 작업 내역 : 
src/App.jsx
src/components/Header/Header.jsx
src/pages/Main/Post/PostEdit/PostEdit.jsx

### 기대 결과 및 스크린샷
<img width="497" alt="스크린샷 2022-12-27 오후 6 11 35" src="https://user-images.githubusercontent.com/109451148/209642794-f9b1e908-a12f-4f53-a665-daa4e9f06297.png">


### Issue Number
close : #105
