### PR TITLE
Feat : post 상세 페이지 구현

### DIFF
--- a/src/components/CommentInput/CommentInputStyle.jsx
+++ b/src/components/CommentInput/CommentInputStyle.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const CommentInputContainerStyle = styled.div`
   width: 100%;
   height: 61px;
-  position: fixed;
+  position: sticky;
   bottom: 0;
   border-top: 1px solid var(--sub-grey-C4);
   background-color: var(--white);

--- a/src/components/CommentsIcon/CommentIcon.jsx
+++ b/src/components/CommentsIcon/CommentIcon.jsx
@@ -1,24 +1,11 @@
 import React from 'react';
-import styled from 'styled-components';
-import CommentImg from '../../assets/img/icon-message-circle.png';
-
-const CommentStyle = styled.span`
-  display: flex;
-  align-items: center;
-  gap: 7.82px;
-  color: var(--main-grey-76);
-`;
-
-const CommentImgStyle = styled.img`
-  width: 16.36px;
-  height: 14.55px;
-`;
+import { CommentWrapStyle, CommentbtnStyle } from './CommentIconStyle';
 
 export default function CommentIcon({ commentCount }) {
   return (
-    <CommentStyle>
-      <CommentImgStyle src={CommentImg} alt="" />
+    <CommentWrapStyle>
+      <CommentbtnStyle />
       <span>{commentCount}</span>
-    </CommentStyle>
+    </CommentWrapStyle>
   );
 }

--- a/src/components/CommentsIcon/CommentIconStyle.jsx
+++ b/src/components/CommentsIcon/CommentIconStyle.jsx
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+import CommentImg from '../../assets/img/icon-message-circle.png';
+
+export const CommentWrapStyle = styled.span`
+  display: flex;
+  align-items: center;
+  gap: 7.82px;
+  color: var(--main-grey-76);
+`;
+
+export const CommentbtnStyle = styled.button`
+  width: 17px;
+  height: 15px;
+  background: url(${CommentImg}) no-repeat 50%;
+  background-size: cover;
+`;

--- a/src/components/PostCard/PostCard.jsx
+++ b/src/components/PostCard/PostCard.jsx
@@ -15,7 +15,7 @@ import {
 } from './PostCardStyle';
 
 export default function PostCard({ post, author }) {
-  console.log(post);
+  // console.log(post);
   const accountName = author.accountname;
   const postDate =
     post.createdAt !== post.updatedAt
@@ -50,7 +50,9 @@ export default function PostCard({ post, author }) {
           : null}
         <PostCountDivStyle>
           <HeartIcon heartCount={post.heartCount} />
-          <CommentIcon commentCount={post.commentCount} />
+          <Link to={`/post/${post.id}`}>
+            <CommentIcon commentCount={post.commentCount} />
+          </Link>
         </PostCountDivStyle>
         <PostDateStyle>{`${year}년 ${month}월 ${date}일`}</PostDateStyle>
       </PostDivStyle>

--- a/src/components/PostCard/PostCard.jsx
+++ b/src/components/PostCard/PostCard.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import PostImg from '../../assets/img/unsplash_FWtiv70Z_ZY.png';
 import HeartIcon from '../HearIcon/HeartIcon';
 import CommentIcon from '../CommentsIcon/CommentIcon';
 import ProfileImgAccount from '../ProfileImgAccount/ProfileImgAccount';
@@ -16,14 +15,15 @@ import {
 } from './PostCardStyle';
 
 export default function PostCard({ post, author }) {
+  console.log(post);
   const accountName = author.accountname;
   const postDate =
     post.createdAt !== post.updatedAt
-      ? post.updatedAt.slice(0, 10).replaceAll('-', '')
-      : post.createdAt.slice(0, 10).replaceAll('-', '');
-  const year = postDate.slice(0, 4);
-  const month = postDate.slice(4, 6);
-  const date = postDate.slice(6, 8);
+      ? post.updatedAt?.slice(0, 10).replaceAll('-', '')
+      : post.createdAt?.slice(0, 10).replaceAll('-', '');
+  const year = postDate?.slice(0, 4);
+  const month = postDate?.slice(4, 6);
+  const date = postDate?.slice(6, 8);
 
   return (
     <PostAccountLiStyle>

--- a/src/pages/Main/Post/Post.jsx
+++ b/src/pages/Main/Post/Post.jsx
@@ -1,5 +1,9 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { useParams } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import { authAtom } from '../../../_state/auth';
+import API from '../../../API';
 import { PageWrap, ConWrap } from '../../../styles/GlobalStyles';
 import PostCard from '../../../components/PostCard/PostCard';
 import Comment from '../../../components/Comment/Comment';
@@ -24,12 +28,48 @@ const CommentContainerStyle = styled.div`
 `;
 
 export default function Post() {
+  const auth = useRecoilValue(authAtom);
+  const { id } = useParams();
+  const [postData, setPostData] = useState('');
+  const [postAuthor, setPostAuthor] = useState('');
+
+  useEffect(() => {
+    const GetPost = async () => {
+      try {
+        const res = await API.get(`/post/${id}`, {
+          headers: {
+            Authorization: `Bearer ${auth}`,
+            'Content-type': 'application/json',
+          },
+        });
+        console.log(res);
+        console.log(res.data.post);
+        const { post } = res.data;
+        console.log(post);
+        setPostData(post);
+        const { author } = res.data.post;
+        setPostAuthor(author);
+      } catch (err) {
+        if (err.response) {
+          // 응답코드 2xx가 아닌 경우
+          console.log(err.response.data);
+          console.log(err.response.status);
+          console.log(err.response.headers);
+        } else {
+          console.log(`Error: ${err.message}`);
+        }
+      }
+    };
+    GetPost();
+  }, []);
+
+  console.log(postData);
   return (
     <PageWrapStyle>
-      <Header />
+      <Header id={id} />
       <ConWrapStyle>
         <PostCardUlCont>
-          <PostCard />
+          <PostCard post={postData} author={postAuthor} />
         </PostCardUlCont>
         <CommentContainerStyle>
           <Comment


### PR DESCRIPTION
### 무엇을 위한 PR인가요?
- [x] 기능 추가 : 게시글의 상세 페이지를 구현했습니다. (post/:id)

### 전달사항
- Post.jsx에서 게시글을 불러옵니다. 
- 피드에서 게시글 하단에 있는 댓글 아이콘(CommentIcon)을 누르면 게시글 상세 페이지로 이동합니다. 
  CommentIcon을 이미지에서 버튼으로 수정했습니다.
  CommentIcon 컴포넌트의 스타일 컴포넌트 파일을 분리했습니다.
- 상세 페이지에서 댓글을 확인할 수 있습니다.
- 좋아요 기능, 댓글 기능은 추가 예정입니다.
- 댓글 다는 창(CommentInput)을 position:sticky로 수정해 최하단 댓글이 가려지지 않도록 했습니다.
- PostCard에서 slice 오류를 해결했습니다. (참고 : https://bobbyhadz.com/blog/javascript-cannot-read-property-slice-of-undefined)
- post 페이지에 id props를 내려서 필요한 header를 불러올 수 있습니다. `<Header id={id} />`
  헤더 수정 커밋 : https://github.com/One-Hundred-Trials/Good-Harvest-Market/pull/125/commits/95fcbb8be7c07fd1e6268f3ac0261960b22b4862
- 추후 수정할 부분 : 페이지 이동 시 스크롤의 위치가 전 페이지의 위치 그대로 있는 문제
  


### 변경사항 및 이유
- 이유 : 없습니다.


### 작업 내역
- 작업 내역 : 
src/components/CommentInput/CommentInputStyle.jsx
src/components/CommentsIcon/CommentIcon.jsx
src/components/CommentsIcon/CommentIconStyle.jsx
src/components/PostCard/PostCard.jsx
src/pages/Main/Post/Post.jsx


### 기대 결과 및 스크린샷
<img width="501" alt="스크린샷 2022-12-27 오후 7 05 02" src="https://user-images.githubusercontent.com/109451148/209650142-a63eabac-ae3c-4368-85d4-ad3b7752af0b.png">


### Issue Number
close : #126
