### PR TITLE
Feat: 홈 피드 무한 스크롤 구현

### DIFF
--- a/src/pages/Main/Home/Home.jsx
+++ b/src/pages/Main/Home/Home.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 import Header from '../../../components/Header/Header';
@@ -16,43 +16,114 @@ const ConWrapStyle = styled.main`
 export default function Home() {
   const [post, setPost] = useState(null);
   const auth = useRecoilValue(authAtom);
-
   const [hasFollowing, setHasFollowing] = useState(null);
 
-  useEffect(() => {
-    const userFollowingData = async () => {
-      try {
-        const res = await API.get(`/post/feed`, {
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${auth}`,
-          },
-        });
-        const { posts } = res.data;
-        setPost(posts);
-        // console.log(posts);
-        if (res.data.posts !== null) {
-          setHasFollowing(true);
-        }
-      } catch (err) {
-        if (err.response) {
-          // 응답코드 2xx가 아닌 경우
-          console.log(err.response.data);
-          console.log(err.response.status);
-          console.log(err.response.headers);
-        } else {
-          console.log(`Error: ${err.message}`);
-        }
+  //  데이터 계속해서 담을 state
+  const [pageNumber, setPageNumber] = useState(5);
+  const [loading, setLoading] = useState(false);
+  const target = useRef();
+
+  const loadMore = () => setPageNumber((prev) => prev + 3);
+
+  const userFollowingData = async () => {
+    try {
+      const res = await API.get(`/post/feed?limit=${pageNumber}`, {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${auth}`,
+        },
+      });
+      const { posts } = res.data;
+      // setPins((prev) => [...prev, ...posts]);
+      setPost(posts);
+      setLoading(true);
+      //   console.log(posts);
+      if (res.data.posts !== null) {
+        setHasFollowing(true);
       }
-    };
+    } catch (err) {
+      if (err.response) {
+        // 응답코드 2xx가 아닌 경우
+        console.log(err.response.data);
+        console.log(err.response.status);
+        console.log(err.response.headers);
+      } else {
+        console.log(`Error: ${err.message}`);
+      }
+    }
+  };
+
+  useEffect(() => {
     userFollowingData();
-  }, [auth]);
+  }, [pageNumber]);
+
+  useEffect(() => {
+    const num = 1;
+    if (loading) {
+      const observer = new IntersectionObserver(
+        (entries) => {
+          if (entries[0].isIntersecting) {
+            loadMore();
+            // console.log(entries[0]);
+          }
+        },
+        { threshold: 1 }
+      );
+      observer.observe(target.current);
+    }
+  }, [loading]);
+
+  //   useEffect(() => {
+  //   let observer;
+  //   if (target) {
+  //     const onIntersect = async ([entry], observer) => {
+  //       if (entry.isIntersecting) {
+  //         observer.unobserve(entry.target);
+  //         await userFollowingData();
+  //         observer.observe(entry.target);
+  //       }
+  //     };
+  //     observer = new IntersectionObserver(onIntersect, { threshold: 1 });
+  //     observer.observe(target);
+  //   }
+  //   return () => observer && observer.disconnect();
+  // }, [target]);
+
+  // useEffect(() => {
+  //   const userFollowingData = async () => {
+  //     try {
+  //       const res = await API.get(`/post/feed?limit=5`, {
+  //         headers: {
+  //           'Content-Type': 'application/json',
+  //           Authorization: `Bearer ${auth}`,
+  //         },
+  //       });
+  //       const { posts } = res.data;
+  //       setPost(posts);
+  //       // console.log(posts);
+  //       if (res.data.posts !== null) {
+  //         setHasFollowing(true);
+  //       }
+  //     } catch (err) {
+  //       if (err.response) {
+  //         // 응답코드 2xx가 아닌 경우
+  //         console.log(err.response.data);
+  //         console.log(err.response.status);
+  //         console.log(err.response.headers);
+  //       } else {
+  //         console.log(`Error: ${err.message}`);
+  //       }
+  //     }
+  //   };
+  //   userFollowingData();
+  // }, [auth]);
 
   return (
     <>
       <Header>주말의 즐거운 풍년마켓</Header>
       <ConWrapStyle>
         {hasFollowing ? <PostCardList posts={post} /> : <HomeRenderBlank />}
+        <div ref={target} style={{ width: '100%', height: '20px' }}></div>
       </ConWrapStyle>
     </>
   );

--- a/src/pages/Main/Home/Home.jsx
+++ b/src/pages/Main/Home/Home.jsx
@@ -17,8 +17,6 @@ export default function Home() {
   const [post, setPost] = useState(null);
   const auth = useRecoilValue(authAtom);
   const [hasFollowing, setHasFollowing] = useState(null);
-
-  //  데이터 계속해서 담을 state
   const [pageNumber, setPageNumber] = useState(5);
   const [loading, setLoading] = useState(false);
   const target = useRef();
@@ -34,16 +32,13 @@ export default function Home() {
         },
       });
       const { posts } = res.data;
-      // setPins((prev) => [...prev, ...posts]);
       setPost(posts);
       setLoading(true);
-      //   console.log(posts);
       if (res.data.posts !== null) {
         setHasFollowing(true);
       }
     } catch (err) {
       if (err.response) {
-        // 응답코드 2xx가 아닌 경우
         console.log(err.response.data);
         console.log(err.response.status);
         console.log(err.response.headers);
@@ -64,7 +59,6 @@ export default function Home() {
         (entries) => {
           if (entries[0].isIntersecting) {
             loadMore();
-            // console.log(entries[0]);
           }
         },
         { threshold: 1 }
@@ -72,51 +66,6 @@ export default function Home() {
       observer.observe(target.current);
     }
   }, [loading]);
-
-  //   useEffect(() => {
-  //   let observer;
-  //   if (target) {
-  //     const onIntersect = async ([entry], observer) => {
-  //       if (entry.isIntersecting) {
-  //         observer.unobserve(entry.target);
-  //         await userFollowingData();
-  //         observer.observe(entry.target);
-  //       }
-  //     };
-  //     observer = new IntersectionObserver(onIntersect, { threshold: 1 });
-  //     observer.observe(target);
-  //   }
-  //   return () => observer && observer.disconnect();
-  // }, [target]);
-
-  // useEffect(() => {
-  //   const userFollowingData = async () => {
-  //     try {
-  //       const res = await API.get(`/post/feed?limit=5`, {
-  //         headers: {
-  //           'Content-Type': 'application/json',
-  //           Authorization: `Bearer ${auth}`,
-  //         },
-  //       });
-  //       const { posts } = res.data;
-  //       setPost(posts);
-  //       // console.log(posts);
-  //       if (res.data.posts !== null) {
-  //         setHasFollowing(true);
-  //       }
-  //     } catch (err) {
-  //       if (err.response) {
-  //         // 응답코드 2xx가 아닌 경우
-  //         console.log(err.response.data);
-  //         console.log(err.response.status);
-  //         console.log(err.response.headers);
-  //       } else {
-  //         console.log(`Error: ${err.message}`);
-  //       }
-  //     }
-  //   };
-  //   userFollowingData();
-  // }, [auth]);
 
   return (
     <>

--- a/src/pages/Main/Home/Home.jsx
+++ b/src/pages/Main/Home/Home.jsx
@@ -53,7 +53,6 @@ export default function Home() {
   }, [pageNumber]);
 
   useEffect(() => {
-    const num = 1;
     if (loading) {
       const observer = new IntersectionObserver(
         (entries) => {


### PR DESCRIPTION
### 무엇을 위한 PR인가요?
- [x] 기능 추가 : 홈 피드 무한 스크롤 구현



### 전달사항
- IntersectionObserver를 통해 무한 스크롤을 구현했습니다.
- 초기 5개의 게시글만 보여주고 가장 하위의 div태그에 스크롤이 닿으면 추가 데이터가 보여지도록 구현했습니다.


### 변경사항 및 이유
- 이유 : x


### 작업 내역
- 작업 내역 : Home.jsx


### 기대 결과 or 스크린샷


### Issue Number
close : #130 
