### PR TITLE
Feat/logout

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Button from '../../components/Button/Button';
+import LoginModal from '../Modal/LoginModalAlert/LoginModal';
 import iconArrowLeft from '../../assets/img/icon-arrow-left.png';
 import iconMore from '../../assets/img/icon-more-18.png';
 import iconSearch from '../../assets/img/icon-search.png';
@@ -20,6 +21,10 @@ export default function Header({
   go,
   id,
 }) {
+  const [modal, setModal] = useState(false);
+  const modalUp = () => {
+    setModal(true);
+  };
   console.log(id);
   const navigate = useNavigate();
   const path = window.location.pathname;
@@ -30,14 +35,17 @@ export default function Header({
     path === '/chat'
   )
     return (
-      <HeaderStyle>
-        <button onClick={() => navigate(-1)}>
-          <img src={iconArrowLeft} alt="뒤로가기" height="22" />
-        </button>
-        <button>
-          <img src={iconMore} alt="더보기" height="22" />
-        </button>
-      </HeaderStyle>
+      <>
+        <HeaderStyle>
+          <button onClick={() => navigate(-1)}>
+            <img src={iconArrowLeft} alt="뒤로가기" height="22" />
+          </button>
+          <button onClick={modalUp}>
+            <img src={iconMore} alt="더보기" height="22" />
+          </button>
+        </HeaderStyle>
+        {modal && <LoginModal setModal={setModal} />}
+      </>
     );
   else if (path !== '/chat' && path !== '/chat/' && path.includes('/chat/'))
     return (

--- a/src/components/Header/HeaderStyle.jsx
+++ b/src/components/Header/HeaderStyle.jsx
@@ -5,7 +5,7 @@ export const HeaderStyle = styled.header`
   justify-content: space-between;
   align-items: center;
   position: sticky;
-  z-index: 999;
+  z-index: 1;
   top: 0;
   background-color: var(--white);
   width: 100%;

--- a/src/components/Modal/LoginModalAlert/LoginAlert.jsx
+++ b/src/components/Modal/LoginModalAlert/LoginAlert.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 const ModalAlertDiv = styled.div`
@@ -69,14 +70,26 @@ const AlertButtonRight = styled.button`
   color: #0a6d32;
 `;
 
-export default function ModalAlert() {
+export default function ModalAlert({ setAlert }) {
+  const navigate = useNavigate();
+
+  const alertClose = () => {
+    setAlert(false);
+  };
+
+  const logout = () => {
+    localStorage.removeItem('auth');
+    localStorage.removeItem('account');
+    navigate('/login');
+  };
+
   return (
     <ModalAlertDiv>
       <AlertBox>
         <AlertHeader>로그아웃하시겠어요?</AlertHeader>
         <AlertBody>
-          <AlertButtonLeft>취소</AlertButtonLeft>
-          <AlertButtonRight>로그아웃</AlertButtonRight>
+          <AlertButtonLeft onClick={alertClose}>취소</AlertButtonLeft>
+          <AlertButtonRight onClick={logout}>로그아웃</AlertButtonRight>
         </AlertBody>
       </AlertBox>
     </ModalAlertDiv>

--- a/src/components/Modal/LoginModalAlert/LoginModal.jsx
+++ b/src/components/Modal/LoginModalAlert/LoginModal.jsx
@@ -1,17 +1,46 @@
-import React from 'react';
-import { ModalContainerDiv, ModalUl, ModalBtn } from './PostModalStyle';
+import React, { useState, useRef, useEffect } from 'react';
+import {
+  ModalBgtDiv,
+  ModalContainerDiv,
+  ModalUl,
+  ModalBtn,
+} from './LoginModalStyle';
+import LoginAlert from './LoginAlert';
 
-export default function ModalSlide() {
+export default function ModalSlide({ setModal }) {
+  const [alert, setAlert] = useState(false);
+  const alertShow = () => {
+    setAlert(true);
+  };
+
+  const modalRef = useRef();
+  useEffect(() => {
+    const modalTouchCloseHandler = (e) => {
+      if (modalRef.current && !modalRef.current.contains(e.target)) {
+        setModal(false);
+      }
+    };
+    document.addEventListener('mousedown', modalTouchCloseHandler);
+    document.addEventListener('touchstart', modalTouchCloseHandler);
+    return () => {
+      document.removeEventListener('mousedown', modalTouchCloseHandler);
+      document.removeEventListener('touchstart', modalTouchCloseHandler);
+    };
+  });
+
   return (
-    <ModalContainerDiv>
-      <ModalUl>
-        <li>
-          <ModalBtn>삭제</ModalBtn>
-        </li>
-        <li>
-          <ModalBtn>수정</ModalBtn>
-        </li>
-      </ModalUl>
-    </ModalContainerDiv>
+    <ModalBgtDiv>
+      <ModalContainerDiv ref={modalRef}>
+        <ModalUl>
+          <li>
+            <ModalBtn>설정 및 개인정보</ModalBtn>
+          </li>
+          <li>
+            <ModalBtn onClick={alertShow}>로그아웃</ModalBtn>
+          </li>
+        </ModalUl>
+        {alert && <LoginAlert setAlert={setAlert} />}
+      </ModalContainerDiv>
+    </ModalBgtDiv>
   );
 }

--- a/src/components/Modal/LoginModalAlert/LoginModalStyle.jsx
+++ b/src/components/Modal/LoginModalAlert/LoginModalStyle.jsx
@@ -1,13 +1,26 @@
 import React from 'react';
 import styled from 'styled-components';
 
+export const ModalBgtDiv = styled.div`
+  position: fixed;
+  z-index: 1;
+  padding-top: 40vh;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.4);
+`;
+
 export const ModalContainerDiv = styled.div`
   position: fixed;
   width: 100%;
   margin: 0 auto;
   bottom: 0px;
-  box-shadow: 0 1px 20px 0 rgba(0, 0, 0, 0.1);
+  border: 1px solid var(--sub-grey-C4);
   border-radius: 10px 10px 0 0;
+  background-color: var(--white);
 `;
 
 export const ModalUl = styled.ul`


### PR DESCRIPTION
### 무엇을 위한 PR인가요?
- [x] 기능 추가 : 로그아웃 기능 구현


### 전달사항
- localstorage에 저장되어있는 auth와 account를 삭제해주고 로그인 페이지로 이동할 수 있도록 구현했습니다.


### 변경사항 및 이유
- 이유 : 없습니다.


### 작업 내역
- 작업 내역 : Header.jsx, LoginAlert.jsx, LoginModalStyle.jsx, LoginModal.jsx


### 기대 결과
- /my_profile/:id
<img width="388" alt="image" src="https://user-images.githubusercontent.com/71264780/209745428-099bed18-c670-436f-adc8-4dcf05652465.png">


### Issue Number
close : #118 
