### PR TITLE
Modify/login

### DIFF
--- a/src/components/Nav/Nav.jsx
+++ b/src/components/Nav/Nav.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { accountAtom } from '../../_state/auth';
 import NavItem from './NavItem';
@@ -12,7 +13,8 @@ import iconUserFill from '../../assets/img/icon-user-fill.png';
 import { ContainerNav, NavUl } from './NavStyle';
 
 export default function Nav() {
-  const accountname = useRecoilValue(accountAtom);
+  // const accountname = useRecoilValue(accountAtom);
+  const account = JSON.parse(localStorage.getItem('account'));
 
   const IconHome = {
     default: iconHome,
@@ -44,7 +46,7 @@ export default function Nav() {
         </li>
         <li>
           <NavItem
-            link={`/my_profile/${accountname}`}
+            link={`/my_profile/${account}`}
             icon={IconUser}
             name="프로필"
           />

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -17,7 +17,7 @@ import facebook from '../../assets/img/facebook.png';
 import Splash from '../Splash/Splash';
 
 export default function Login() {
-  const children = ['이메일로 로그인', '풍년마켓'];
+  const children = ['이메일로 로그인', '풍년마켓 회원가입'];
   const [visibleSplash, setVisibleSplash] = useState(true);
 
   useEffect(() => {
@@ -35,7 +35,7 @@ export default function Login() {
         <Button size="lg" go="/login/login_email">
           {children[0]}
         </Button>
-        <Button go="/login/login_email" size="lg">
+        <Button go="/login/sign_up" size="lg">
           {children[1]}
         </Button>
         <p>SNS계정으로 로그인하기</p>

--- a/src/pages/Login/LoginEmail/LoginEmail.jsx
+++ b/src/pages/Login/LoginEmail/LoginEmail.jsx
@@ -1,6 +1,6 @@
 import React, { Children, useEffect, useState } from 'react';
 import axios from 'axios';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import Button from '../../../components/Button/Button';
 import Input from '../../../components/Input/Input';
@@ -88,7 +88,12 @@ export default function LoginEmail() {
           {'로그인'}
         </Button>
       </InputFormStyle>
-      <a style={{ display: 'block', marginTop: '20px' }}>이메일로 회원가입</a>
+      <Link
+        to={'/login/sign_up'}
+        style={{ display: 'block', marginTop: '20px' }}
+      >
+        이메일로 회원가입
+      </Link>
     </ContSecStyle>
   );
 }


### PR DESCRIPTION
### 무엇을 위한 PR인가요?
- [x] 기능 추가 : 회원가입 버튼 클릭 시 회원가입 페이지로 이동 기능 추가
- [x] 버그 수정 : 로그인 후 최초 마이프로필 페이지 이동시 accountname이 null인 문제 수정


### 전달사항
- 로그인 페이지의 '풍년마켓 회원가입' 버튼, 로그인이메일 페이지의 '이메일로 회원가입' 버튼 클릭 시 회원가입 페이지로 이동되게 하였습니다.
- Nav.jsx에서 `const accountname = useRecoilValue(accountAtom);` 의 값이 undefined여서 로그인 후 최초 마이프로필 페이지 이동시 url에 accountname이 null인 문제를 발견했습니다.
따라서 `const account = JSON.parse(localStorage.getItem('account'));`으로 수정한 후 문제는 해결되었으나 적절한 방법은 아닌 듯합니다. 추후 보완이 필요해보입니다.


### 변경사항 및 이유
- 이유 : 부족한 점 수정 및 보완을 위해


### 작업 내역
- 작업 내역 : changed files 참고 부탁드립니다.


### 기대 결과 or 스크린샷
![image](https://user-images.githubusercontent.com/38063033/209948613-878cdfcd-cfae-4040-8c85-46fef4874429.png)


### Issue Number
close : #137 
