### PR TITLE
Modify : PostCard 컴포넌트 수정

### DIFF
--- a/src/components/AlbumIcon/AlbumIcon.jsx
+++ b/src/components/AlbumIcon/AlbumIcon.jsx
@@ -14,7 +14,7 @@ export default function AlbumIcon({ toggle, onclick }) {
       <img
         src={toggle ? iconPostAlbumOn : iconPostAlbumOff}
         alt="album"
-        height="22"
+        height="26"
       />
     </BtnStyle>
   );

--- a/src/components/Comment/Comment.jsx
+++ b/src/components/Comment/Comment.jsx
@@ -8,10 +8,10 @@ import {
   CommentContainerStyle,
   InfoStyle,
   InfoDiv,
-  ProfileImg,
   MoreBtn,
   TxtStyle,
 } from './CommentStyle';
+import ProfileImg from '../ProfileImg/ProfileImg';
 
 export default function Comment({ comment, postId, deleteComment }) {
   const userAccount = useRecoilValue(accountAtom);
@@ -49,20 +49,17 @@ export default function Comment({ comment, postId, deleteComment }) {
     },
   };
 
-  // 댓글 삭제
   const commentDelHandler = async () => {
     try {
-      const res = await API.delete(`/post/${postId}/comments/${comment.id}`, {
+      await API.delete(`/post/${postId}/comments/${comment.id}`, {
         headers: {
           'Content-type': 'application/json',
           Authorization: `Bearer ${auth}`,
         },
       });
-      console.log(res);
       deleteComment();
     } catch (err) {
       if (err.response) {
-        // 응답코드 2xx가 아닌 경우
         console.log(err.response.data);
         console.log(err.response.status);
         console.log(err.response.headers);
@@ -72,10 +69,9 @@ export default function Comment({ comment, postId, deleteComment }) {
     }
   };
 
-  // 댓글 신고
   const commentReportHandler = async () => {
     try {
-      const res = await API.post(
+      await API.post(
         `/post/${postId}/comments/${comment.id}/report`,
         JSON.stringify(commentReport),
         {
@@ -85,12 +81,10 @@ export default function Comment({ comment, postId, deleteComment }) {
           },
         }
       );
-      console.log(res);
       setReportComment(`신고가 접수되었습니다.`);
       setModal(false);
     } catch (err) {
       if (err.response) {
-        // 응답코드 2xx가 아닌 경우
         console.log(err.response.data);
         console.log(err.response.status);
         console.log(err.response.headers);
@@ -105,7 +99,12 @@ export default function Comment({ comment, postId, deleteComment }) {
       <CommentContainerStyle>
         <InfoStyle>
           <InfoDiv>
-            <ProfileImg src={comment.author.image} alt="" />
+            <ProfileImg
+              width="36px"
+              height="36px"
+              image={comment.author.image}
+              alt=""
+            />
             <strong>{comment.author.username}</strong>
             <span>{nowDate}</span>
           </InfoDiv>

--- a/src/components/Comment/Comment.jsx
+++ b/src/components/Comment/Comment.jsx
@@ -51,12 +51,13 @@ export default function Comment({ comment, postId, deleteComment }) {
 
   const commentDelHandler = async () => {
     try {
-      await API.delete(`/post/${postId}/comments/${comment.id}`, {
+      const res = await API.delete(`/post/${postId}/comments/${comment.id}`, {
         headers: {
           'Content-type': 'application/json',
           Authorization: `Bearer ${auth}`,
         },
       });
+      console.log(res);
       deleteComment();
     } catch (err) {
       if (err.response) {
@@ -71,7 +72,7 @@ export default function Comment({ comment, postId, deleteComment }) {
 
   const commentReportHandler = async () => {
     try {
-      await API.post(
+      const res = await API.post(
         `/post/${postId}/comments/${comment.id}/report`,
         JSON.stringify(commentReport),
         {
@@ -81,6 +82,7 @@ export default function Comment({ comment, postId, deleteComment }) {
           },
         }
       );
+      console.log(res);
       setReportComment(`신고가 접수되었습니다.`);
       setModal(false);
     } catch (err) {

--- a/src/components/Comment/CommentStyle.jsx
+++ b/src/components/Comment/CommentStyle.jsx
@@ -31,12 +31,6 @@ export const InfoDiv = styled.div`
   }
 `;
 
-export const ProfileImg = styled.img`
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-`;
-
 export const MoreBtn = styled.button`
   img {
     width: 20px;

--- a/src/components/CommentInput/CommentInput.jsx
+++ b/src/components/CommentInput/CommentInput.jsx
@@ -42,12 +42,17 @@ export default function CommentInput({ upDateComment }) {
 
   const commentUpload = async (e) => {
     try {
-      await API.post(`/post/${id}/comments`, JSON.stringify(commentData), {
-        headers: {
-          Authorization: `Bearer ${auth}`,
-          'Content-type': 'application/json',
-        },
-      });
+      const res = await API.post(
+        `/post/${id}/comments`,
+        JSON.stringify(commentData),
+        {
+          headers: {
+            Authorization: `Bearer ${auth}`,
+            'Content-type': 'application/json',
+          },
+        }
+      );
+      console.log(res);
       inputClear();
       upDateComment();
     } catch (err) {

--- a/src/components/CommentInput/CommentInput.jsx
+++ b/src/components/CommentInput/CommentInput.jsx
@@ -2,12 +2,12 @@ import React, { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import API from '../../API';
-import ProfileImg from '../../assets/img/basic-profile-36.png';
+import ProfileImg from '../ProfileImg/ProfileImg';
 import { authAtom } from '../../_state/auth';
+import BasicProfile from '../../assets/img/basic-profile.png';
 import {
   CommentInputContainerStyle,
   CommentForm,
-  MyProfileImg,
   CommentTxtInput,
   UploadBtn,
 } from './CommentInputStyle';
@@ -42,22 +42,16 @@ export default function CommentInput({ upDateComment }) {
 
   const commentUpload = async (e) => {
     try {
-      const res = await API.post(
-        `/post/${id}/comments`,
-        JSON.stringify(commentData),
-        {
-          headers: {
-            Authorization: `Bearer ${auth}`,
-            'Content-type': 'application/json',
-          },
-        }
-      );
-      console.log(res);
+      await API.post(`/post/${id}/comments`, JSON.stringify(commentData), {
+        headers: {
+          Authorization: `Bearer ${auth}`,
+          'Content-type': 'application/json',
+        },
+      });
       inputClear();
       upDateComment();
     } catch (err) {
       if (err.response) {
-        // 응답코드 2xx가 아닌 경우
         console.log(err.response.data);
         console.log(err.response.status);
         console.log(err.response.headers);
@@ -75,7 +69,12 @@ export default function CommentInput({ upDateComment }) {
   return (
     <CommentInputContainerStyle>
       <CommentForm>
-        <MyProfileImg src={ProfileImg} alt="프로필 사진" />
+        <ProfileImg
+          width="36px"
+          height="36px"
+          image={BasicProfile}
+          alt="프로필 사진"
+        />
         <CommentTxtInput
           type="text"
           id="commentInput"

--- a/src/components/CommentInput/CommentInputStyle.jsx
+++ b/src/components/CommentInput/CommentInputStyle.jsx
@@ -11,16 +11,12 @@ export const CommentInputContainerStyle = styled.div`
 export const CommentForm = styled.form`
   display: flex;
   justify-content: space-between;
-`;
-
-export const MyProfileImg = styled.img`
-  width: 36px;
-  height: 36px;
-  margin: 13px 18px 12px 16px;
+  padding: 12px 16px;
 `;
 
 export const CommentTxtInput = styled.input`
   width: 100%;
+  margin: 0 18px;
   font-size: 1.4rem;
   border-style: none;
   outline: none;
@@ -32,9 +28,6 @@ export const CommentTxtInput = styled.input`
 
 export const UploadBtn = styled.button`
   flex-shrink: 0;
-  padding: 16px;
-  background: inherit;
-  border: none;
   font-size: 1.4rem;
   font-weight: 500;
   color: ${(props) => props.color};

--- a/src/components/PostAlbumList/PostAlbumList.jsx
+++ b/src/components/PostAlbumList/PostAlbumList.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import unsplashImg from '../../assets/img/unsplash_5MF7EFgy02U.png';
 import iconImgLayer from '../../assets/img/iccon-img-layers.png';
 
 const ListStyle = styled.li`
@@ -12,8 +11,9 @@ const ListStyle = styled.li`
     right: 6px;
     width: 20px;
     height: 20px;
+    /* 
     background-image: url(${iconImgLayer});
-    background-size: contain;
+    background-size: contain; */
   }
   img {
     display: block;

--- a/src/components/PostCard/PostCard.jsx
+++ b/src/components/PostCard/PostCard.jsx
@@ -40,13 +40,18 @@ export default function PostCard({ post, author }) {
   const month = postDate?.slice(4, 6);
   const date = postDate?.slice(6, 8);
 
+  const imgNum = post.image.split(',');
   const prevBtn = () => {
     if (slidePx < 0) setSlidePx(slidePx + 304);
   };
   const nextBtn = () => {
-    if (slidePx > -608) setSlidePx(slidePx - 304);
+    if (imgNum.length === 2 && slidePx > -304) {
+      setSlidePx(slidePx - 304);
+    } else if (imgNum.length === 3 && slidePx > -608) {
+      setSlidePx(slidePx - 304);
+    }
   };
-  console.log(slidePx);
+
   return (
     <>
       <PostAccountLiStyle>
@@ -76,10 +81,16 @@ export default function PostCard({ post, author }) {
           <PostContentsStyle>{post.content}</PostContentsStyle>
           <PostCarouselStyle>
             <PostCarouselContStyle transform={slidePx}>
-              {post.image ? <PostImgStyle src={post.image} alt="" /> : null}
-              {post.image ? <PostImgStyle src={post.image} alt="" /> : null}
+              {post.image
+                ? imgNum.map((ImgUrl, index) => (
+                    <div key={index}>
+                      {' '}
+                      <PostImgStyle src={ImgUrl} alt="" />{' '}
+                    </div>
+                  ))
+                : null}
             </PostCarouselContStyle>
-            {post.image ? (
+            {imgNum.length > 1 ? (
               <PostCarouselBtnsContStyle>
                 <PostCarouselBtnStyle onClick={prevBtn}>
                   &#xE000;

--- a/src/components/PostCard/PostCard.jsx
+++ b/src/components/PostCard/PostCard.jsx
@@ -13,6 +13,9 @@ import {
   PostIconMoreStyle,
   PostDivStyle,
   PostContentsStyle,
+  PostCarouselStyle,
+  PostCarouselBtnsContStyle,
+  PostCarouselBtnStyle,
   PostImgStyle,
   PostCountDivStyle,
   PostDateStyle,
@@ -58,10 +61,16 @@ export default function PostCard({ post, author }) {
           </Link>
           <PostIconMoreStyle onClick={modalUp} />
         </PostProfileDivStyle>
-
         <PostDivStyle>
           <PostContentsStyle>{post.content}</PostContentsStyle>
-          {post.image ? <PostImgStyle src={post.image} alt="" /> : null}
+          <PostCarouselStyle>
+            {post.image ? <PostImgStyle src={post.image} alt="" /> : null}
+            {post.image ? <PostImgStyle src={post.image} alt="" /> : null}
+            <PostCarouselBtnsContStyle>
+              <PostCarouselBtnStyle>&#xE000;</PostCarouselBtnStyle>
+              <PostCarouselBtnStyle>&#xE001;</PostCarouselBtnStyle>
+            </PostCarouselBtnsContStyle>
+          </PostCarouselStyle>
           <PostCountDivStyle>
             <HeartIcon heartCount={post.heartCount} />
             <Link to={`/post/${post.id}`}>

--- a/src/components/PostCard/PostCard.jsx
+++ b/src/components/PostCard/PostCard.jsx
@@ -40,7 +40,7 @@ export default function PostCard({ post, author }) {
   const month = postDate?.slice(4, 6);
   const date = postDate?.slice(6, 8);
 
-  const imgNum = post.image.split(',');
+  const imgNum = post.image?.split(',');
   const prevBtn = () => {
     if (slidePx < 0) setSlidePx(slidePx + 304);
   };
@@ -90,7 +90,7 @@ export default function PostCard({ post, author }) {
                   ))
                 : null}
             </PostCarouselContStyle>
-            {imgNum.length > 1 ? (
+            {imgNum?.length > 1 ? (
               <PostCarouselBtnsContStyle>
                 <PostCarouselBtnStyle onClick={prevBtn}>
                   &#xE000;

--- a/src/components/PostCard/PostCard.jsx
+++ b/src/components/PostCard/PostCard.jsx
@@ -14,6 +14,7 @@ import {
   PostDivStyle,
   PostContentsStyle,
   PostCarouselStyle,
+  PostCarouselContStyle,
   PostCarouselBtnsContStyle,
   PostCarouselBtnStyle,
   PostImgStyle,
@@ -23,10 +24,13 @@ import {
 
 export default function PostCard({ post, author }) {
   const userAccount = useRecoilValue(accountAtom);
+  const [slidePx, setSlidePx] = useState(0);
   const [modal, setModal] = useState(false);
+
   const modalUp = () => {
     setModal(true);
   };
+
   const accountName = author.accountname;
   const postDate =
     post.createdAt !== post.updatedAt
@@ -36,6 +40,13 @@ export default function PostCard({ post, author }) {
   const month = postDate?.slice(4, 6);
   const date = postDate?.slice(6, 8);
 
+  const prevBtn = () => {
+    if (slidePx < 0) setSlidePx(slidePx + 304);
+  };
+  const nextBtn = () => {
+    if (slidePx > -608) setSlidePx(slidePx - 304);
+  };
+  console.log(slidePx);
   return (
     <>
       <PostAccountLiStyle>
@@ -64,12 +75,20 @@ export default function PostCard({ post, author }) {
         <PostDivStyle>
           <PostContentsStyle>{post.content}</PostContentsStyle>
           <PostCarouselStyle>
-            {post.image ? <PostImgStyle src={post.image} alt="" /> : null}
-            {post.image ? <PostImgStyle src={post.image} alt="" /> : null}
-            <PostCarouselBtnsContStyle>
-              <PostCarouselBtnStyle>&#xE000;</PostCarouselBtnStyle>
-              <PostCarouselBtnStyle>&#xE001;</PostCarouselBtnStyle>
-            </PostCarouselBtnsContStyle>
+            <PostCarouselContStyle transform={slidePx}>
+              {post.image ? <PostImgStyle src={post.image} alt="" /> : null}
+              {post.image ? <PostImgStyle src={post.image} alt="" /> : null}
+            </PostCarouselContStyle>
+            {post.image ? (
+              <PostCarouselBtnsContStyle>
+                <PostCarouselBtnStyle onClick={prevBtn}>
+                  &#xE000;
+                </PostCarouselBtnStyle>
+                <PostCarouselBtnStyle onClick={nextBtn}>
+                  &#xE001;
+                </PostCarouselBtnStyle>
+              </PostCarouselBtnsContStyle>
+            ) : null}
           </PostCarouselStyle>
           <PostCountDivStyle>
             <HeartIcon heartCount={post.heartCount} />

--- a/src/components/PostCard/PostCard.jsx
+++ b/src/components/PostCard/PostCard.jsx
@@ -19,8 +19,6 @@ import {
 } from './PostCardStyle';
 
 export default function PostCard({ post, author }) {
-  // console.log(post);
-
   const userAccount = useRecoilValue(accountAtom);
   const [modal, setModal] = useState(false);
   const modalUp = () => {
@@ -42,6 +40,7 @@ export default function PostCard({ post, author }) {
           <PostProfileDivStyle>
             <ProfileImgAccount
               width="42px"
+              height="42px"
               margin="0 0 0 12px"
               namemarginbottom="2px"
               post={post}

--- a/src/components/PostCard/PostCard.jsx
+++ b/src/components/PostCard/PostCard.jsx
@@ -36,22 +36,29 @@ export default function PostCard({ post, author }) {
   return (
     <>
       <PostAccountLiStyle>
-        <Link to={`/user_profile/${accountName}`}>
-          <PostProfileDivStyle>
+        <PostProfileDivStyle>
+          <Link
+            to={
+              userAccount === accountName
+                ? `/my_profile/${accountName}`
+                : `/user_profile/${accountName}`
+            }
+          >
             <ProfileImgAccount
               width="42px"
               height="42px"
               margin="0 0 0 12px"
-              namemarginbottom="2px"
+              namemarginbottom="3px"
               post={post}
               author={author}
               username={author.username}
               accountname={author.accountname}
               image={author.image}
             />
-            <PostIconMoreStyle onClick={modalUp} />
-          </PostProfileDivStyle>
-        </Link>
+          </Link>
+          <PostIconMoreStyle onClick={modalUp} />
+        </PostProfileDivStyle>
+
         <PostDivStyle>
           <PostContentsStyle>{post.content}</PostContentsStyle>
           {post.image ? <PostImgStyle src={post.image} alt="" /> : null}

--- a/src/components/PostCard/PostCardStyle.jsx
+++ b/src/components/PostCard/PostCardStyle.jsx
@@ -26,28 +26,23 @@ export const PostContentsStyle = styled.p`
   font-size: 1.4rem;
 `;
 
-export const PostCarouselStyle = styled.div`
+export const PostCarouselStyle = styled.article`
   position: relative;
   width: 304px;
-  max-height: 450px;
+  max-height: 400px;
   margin-bottom: 15px;
-  display: flex;
-  gap: 10px;
   overflow: hidden;
   border-radius: 10px;
-  background-color: yellow;
   background-color: var(--light-grey-F2);
 `;
 
+export const PostCarouselContStyle = styled.div`
+  display: flex;
+  max-height: 400px;
+`;
+
 export const PostImgStyle = styled.img`
-  // width: 100;
-  //  height: 100%;
-  //object-fit: cover;
-  /* position: absolute;
-  /* top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%); */
-  flex-shrink: 0;
+  min-width: 304px;
   object-fit: contain;
 `;
 

--- a/src/components/PostCard/PostCardStyle.jsx
+++ b/src/components/PostCard/PostCardStyle.jsx
@@ -39,6 +39,8 @@ export const PostCarouselStyle = styled.article`
 export const PostCarouselContStyle = styled.div`
   display: flex;
   max-height: 400px;
+  transition: 0.5s;
+  transform: translateX(${(props) => props.transform}px);
 `;
 
 export const PostImgStyle = styled.img`

--- a/src/components/PostCard/PostCardStyle.jsx
+++ b/src/components/PostCard/PostCardStyle.jsx
@@ -22,7 +22,7 @@ export const PostDivStyle = styled.div`
 
 export const PostContentsStyle = styled.p`
   margin-bottom: 16px;
-  line-height: 1.8rem;
+  line-height: 1.9rem;
   font-size: 1.4rem;
 `;
 
@@ -76,6 +76,6 @@ export const PostCountDivStyle = styled.div`
 `;
 
 export const PostDateStyle = styled.p`
-  margin-top: 19px;
+  margin-top: 17px;
   color: var(--main-grey-76);
 `;

--- a/src/components/PostCard/PostCardStyle.jsx
+++ b/src/components/PostCard/PostCardStyle.jsx
@@ -38,6 +38,7 @@ export const PostCarouselStyle = styled.article`
 
 export const PostCarouselContStyle = styled.div`
   display: flex;
+  align-items: center;
   max-height: 400px;
   transition: 0.5s;
   transform: translateX(${(props) => props.transform}px);

--- a/src/components/PostCard/PostCardStyle.jsx
+++ b/src/components/PostCard/PostCardStyle.jsx
@@ -26,8 +26,50 @@ export const PostContentsStyle = styled.p`
   font-size: 1.4rem;
 `;
 
-export const PostImgStyle = styled.img`
+export const PostCarouselStyle = styled.div`
+  position: relative;
+  width: 304px;
+  max-height: 450px;
   margin-bottom: 15px;
+  display: flex;
+  gap: 10px;
+  overflow: hidden;
+  border-radius: 10px;
+  background-color: yellow;
+  background-color: var(--light-grey-F2);
+`;
+
+export const PostImgStyle = styled.img`
+  // width: 100;
+  //  height: 100%;
+  //object-fit: cover;
+  /* position: absolute;
+  /* top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%); */
+  flex-shrink: 0;
+  object-fit: contain;
+`;
+
+export const PostCarouselBtnsContStyle = styled.div`
+  position: absolute;
+  display: flex;
+  justify-content: space-between;
+  width: 280px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+`;
+
+export const PostCarouselBtnStyle = styled.button`
+  width: 22px;
+  height: 22px;
+  font-size: 1.1rem;
+  line-height: 19px;
+  border-radius: 50%;
+  border: 1.5px solid var(--main-grey-76);
+  color: var(--main-grey-76);
+  background-color: rgba(255, 255, 255);
 `;
 
 export const PostCountDivStyle = styled.div`

--- a/src/components/PostCardList/PostCardList.jsx
+++ b/src/components/PostCardList/PostCardList.jsx
@@ -5,7 +5,7 @@ import PostCard from '../PostCard/PostCard';
 const ContUlStyle = styled.ul`
   background-color: var(--white);
   & li + li {
-    margin-top: 20px;
+    margin-top: 35px;
   }
 `;
 

--- a/src/components/Product/ProductStyle.jsx
+++ b/src/components/Product/ProductStyle.jsx
@@ -16,10 +16,9 @@ export const ProductImgWrap = styled.div`
 `;
 
 export const ProductImg = styled.img`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 `;
 
 export const ProductName = styled.p`

--- a/src/components/ProfileImg/ProfileImg.jsx
+++ b/src/components/ProfileImg/ProfileImg.jsx
@@ -1,14 +1,11 @@
 import React from 'react';
 import DefaultProfileImg from '../../assets/img/basic-profile.png';
-import ProfileImgStyle from './ProfileImgStyle';
+import { ProfileImgStyle, ProfileContImg } from './ProfileImgStyle';
 
 export default function ProfileImg({ image, width, height }) {
   return (
-    <ProfileImgStyle
-      src={image}
-      alt="프로필 이미지"
-      width={width}
-      height={height}
-    />
+    <ProfileContImg width={width} height={height}>
+      <ProfileImgStyle src={image} alt="프로필 이미지" />
+    </ProfileContImg>
   );
 }

--- a/src/components/ProfileImg/ProfileImgStyle.jsx
+++ b/src/components/ProfileImg/ProfileImgStyle.jsx
@@ -1,9 +1,16 @@
 import styled from 'styled-components';
 
-const ProfileImgStyle = styled.img`
+export const ProfileContImg = styled.div`
+  position: relative;
+  flex-shrink: 0;
   border-radius: 50%;
   width: ${(props) => props.width};
   height: ${(props) => props.height};
+  overflow: hidden;
 `;
 
-export default ProfileImgStyle;
+export const ProfileImgStyle = styled.img`
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+`;

--- a/src/components/ProfileImgAccount/ProfileImgAccount.jsx
+++ b/src/components/ProfileImgAccount/ProfileImgAccount.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import ProfileAccount from '../ProfileAccount/ProfileAccount';
-import DefaultProfileImg from '../../assets/img/basic-profile.png';
 import { ProfileImgContainerStyle } from './ProfileImgAccountStyle';
 import ProfileImg from '../ProfileImg/ProfileImg';
 

--- a/src/styles/GlobalStyles.jsx
+++ b/src/styles/GlobalStyles.jsx
@@ -24,6 +24,11 @@ export const GlobalStyle = createGlobalStyle`
     }
     body {
       font-family: "Spoqa Han Sans Neo", "sans-serif";
+      -ms-overflow-style: none;
+      scrollbar-width: none;
+      &::-webkit-scrollbar {
+        display: none;
+      }
     }
     a {
       text-decoration: none;
@@ -71,7 +76,7 @@ export const ConWrap = css`
   width: 390px;
   flex-grow: 1;
   background-color: var(--white);
-  box-shadow: -1px 0 20px -1px #f2f2f2, 1px 0 20px -1px #f2f2f2; ;
+  box-shadow: -1px 0 20px -1px #f2f2f2, 1px 0 20px -1px #f2f2f2;
 `;
 
 export const Wrap = css`


### PR DESCRIPTION
### 무엇을 위한 PR인가요?
- [x] 기능 추가 : 여러장의 이미지를 캐러셀로 확인할 수 있게 게시물을 수정했습니다.
- [x] 스타일 : 세부적인 간격, 스타일 등을 함께 수정했습니다.


### 전달사항
- 여러장의 이미지일때만 캐러셀 버튼이 보이게 해두었으나 이미지 리스트의 양 끝에 도달했을때 선택적으로 좌우 버튼을 보여주는 기능은 아직 구현을 못했습니다.


### 변경사항 및 이유
- 이유 : 어플리케이션 전체에 사용되는 프로필 이미지의 스타일을 수정했습니다. 어제 자 코드 rebase 해왔을 때 충돌 없이 잘 병합되어 다른 문제는 없을 듯 합니다.
-  스타일 수정을 하고있었기에 어플리케이션 전체의 스크롤바 제거를 함께 진행했습니다.
- 게시물 앨범형 선택 아이콘이 깨져있어 픽셀을 수정했습니다. 또 저희 어플리케이션에선 여러장 업로드가 아직 불가하므로 여러장을 표시하는 아이콘을 나타내주는 이미지를 주석처리 해두었습니다.


### 작업 내역
- 작업 내역 : Files Changed 참고 부탁드립니다.

### 스크린샷
<img width="394" alt="스크린샷 2023-01-02 오전 11 24 46" src="https://user-images.githubusercontent.com/94048689/210191290-dd47317e-88f7-400f-8d52-bd6d8bba5065.png">


### Issue Number
close : #151 
