### PR TITLE
Add : 404페이지, Homefeed 이동 구현

### DIFF
--- a/src/components/Blank/Blank.jsx
+++ b/src/components/Blank/Blank.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import Button from '../Button/Button';
 import { BlankImgStyle, BlankTextStyle } from './BlankStyle';
 
-export default function Blank({ src, width, text, children }) {
+export default function Blank({ src, width, text, children, clickHandler }) {
   return (
     <div>
       <BlankImgStyle src={src} width={width} />
       <BlankTextStyle>{text}</BlankTextStyle>
-      <Button size="m" variant="abled">
+      <Button size="m" variant="abled" onClick={clickHandler}>
         {children}
       </Button>
     </div>

--- a/src/components/HomeRender/HomeRenderBlank.jsx
+++ b/src/components/HomeRender/HomeRenderBlank.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
 import Blank from '../Blank/Blank';
 import DuckBlank from '../../assets/img/duck-blank.png';
 
@@ -13,12 +14,15 @@ const BlankWrap = styled.section`
 `;
 
 export default function HomeRenderBlank() {
+  const navigate = useNavigate();
+
   return (
     <BlankWrap>
       <Blank
         src={DuckBlank}
         width="180px"
         text="유저를 검색해 팔로우 해보세요!"
+        clickHandler={() => navigate('/search')}
       >
         검색하기
       </Blank>

--- a/src/pages/NotFound/NotFound.jsx
+++ b/src/pages/NotFound/NotFound.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
 import icon404Img from '../../assets/img/icon-404.png';
 import Blank from '../../components/Blank/Blank';
 
@@ -13,12 +14,15 @@ const ContainerSectionStyle = styled.section`
 `;
 
 export default function NotFound() {
+  const navigate = useNavigate();
+
   return (
     <ContainerSectionStyle>
       <Blank
         src={icon404Img}
         width="300px"
         text="요청하신 페이지를 찾을 수 없어요!"
+        clickHandler={() => navigate(-1)}
       >
         이전 페이지
       </Blank>


### PR DESCRIPTION
### 무엇을 위한 PR인가요?
- [x] 기능 추가 : 404페이지, Homefeed 이동 구현


### 전달사항
- 없음


### 변경사항 및 이유
- 이유 : Blank.jsx에 onClick 이벤트 props를 추가하여 원하는 페이지로 이동 가능하게 만들었습니다.

### 작업 내역
- 작업 내역 : src/components/Blank/Blank.jsx
- src/components/HomeRender/HomeRenderBlank.jsx
- src/pages/NotFound/NotFound.jsx


### 기대 결과
-  404페이지에서 `이전페이지`를 클릭 시 한 단계 뒤로, 홈피드에서 '유저를 검색해보세요!' 페이지 렌더링 시 버튼을 클릭하면 검색 페이지로 이동할 수 있습니다.


### Issue Number
close : #85
