### PR TITLE
Modify : 게시글 신고 후 유저 프로필 이동 에러 해결

### DIFF
--- a/src/components/Modal/PostModalAlert/PostReportAlert.jsx
+++ b/src/components/Modal/PostModalAlert/PostReportAlert.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { useParams } from 'react-router-dom';
-// import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import API from '../../../API';
 import { authAtom } from '../../../_state/auth';
@@ -13,22 +11,22 @@ import {
   AlertButtonRight,
 } from './PostAlertStyle';
 
-export default function PostReportAlert({ setAlert, postId }) {
+export default function PostReportAlert({ setAlert, postId, accountName }) {
   const auth = useRecoilValue(authAtom);
-  const { id } = useParams();
-  const alertClose = () => {
-    setAlert(false);
-  };
-
-  const moveProfileHandler = () => {
-    window.location.replace(`/user_profile/${id}`);
-  };
-
   const reportData = {
     report: {
       post: postId,
     },
   };
+
+  const alertClose = () => {
+    setAlert(false);
+  };
+
+  const moveProfileHandler = () => {
+    window.location.replace(`/user_profile/${accountName}`);
+  };
+
   const reportHandler = async () => {
     setAlert(true);
     try {
@@ -43,10 +41,11 @@ export default function PostReportAlert({ setAlert, postId }) {
         }
       );
       console.log(res);
-      setAlert(false);
-      moveProfileHandler();
       if (res) {
-        alert('신고가 접수되었습니다.');
+        // alert('신고가 접수되었습니다.');
+        console.log(accountName);
+        setAlert(false);
+        moveProfileHandler();
       }
     } catch (err) {
       if (err.response) {

--- a/src/components/Modal/PostModalAlert/PostReportModal.jsx
+++ b/src/components/Modal/PostModalAlert/PostReportModal.jsx
@@ -1,3 +1,4 @@
+import { logDOM } from '@testing-library/react';
 import React, { useState, useRef, useEffect } from 'react';
 import {
   ModalContainerDiv,
@@ -7,8 +8,9 @@ import {
 } from './PostModalStyle';
 import PostReportAlert from './PostReportAlert';
 
-export default function PostReportModal({ postId, setModal }) {
+export default function PostReportModal({ setModal, postId, accountName }) {
   const [alert, setAlert] = useState(false);
+
   const alertShow = () => {
     setAlert(true);
   };
@@ -36,7 +38,13 @@ export default function PostReportModal({ postId, setModal }) {
             <ModalBtn onClick={alertShow}>신고하기</ModalBtn>
           </li>
         </ModalUl>
-        {alert && <PostReportAlert postId={postId} setAlert={setAlert} />}
+        {alert && (
+          <PostReportAlert
+            accountName={accountName}
+            postId={postId}
+            setAlert={setAlert}
+          />
+        )}
       </ModalContainerDiv>
     </ModalBgtDiv>
   );

--- a/src/components/PostCard/PostCard.jsx
+++ b/src/components/PostCard/PostCard.jsx
@@ -115,7 +115,11 @@ export default function PostCard({ post, author }) {
           {userAccount === accountName ? (
             <PostModal postId={post.id} setModal={setModal} />
           ) : (
-            <PostReportModal postId={post.id} setModal={setModal} />
+            <PostReportModal
+              accountName={author.accountname}
+              postId={post.id}
+              setModal={setModal}
+            />
           )}
         </>
       )}


### PR DESCRIPTION
### 무엇을 위한 PR인가요?
- [x] 버그 수정 : 게시글 신고 후 해당 유저 프로필로 이동합니다.


### 전달사항
- 홈피드 혹은 상세 페이지에서 다른 유저의 게시글을 신고할 때, 신고 후 user_profile/undefined로 이동되는 문제가 있었습니다.


### 변경사항 및 이유
- 이유 : 게시글 작성자의 accountname을 불러오지 못해 발생한 문제였으며, postcard부터 props을 내려줘서 해결했습니다.


### 작업 내역
- 작업 내역 : 
src/components/Modal/PostModalAlert/PostReportAlert.jsx
src/components/Modal/PostModalAlert/PostReportModal.jsx
src/components/PostCard/PostCard.jsx

### 기대 결과 및 스크린샷
<img width="496" alt="스크린샷 2023-01-03 오전 4 38 16" src="https://user-images.githubusercontent.com/109451148/210272577-101fb196-7a5a-40c0-9fcd-fb57b8d910b2.png">
<img width="498" alt="스크린샷 2023-01-03 오전 4 38 23" src="https://user-images.githubusercontent.com/109451148/210272585-de507aa5-1b4b-4c8f-bf09-4f8745dc4c18.png">


### Issue Number
close : #172
