### PR TITLE
Modify : Loading 이미지 깨짐 문제 해결

### DIFF
--- a/src/pages/Loading/LoadingStyle.jsx
+++ b/src/pages/Loading/LoadingStyle.jsx
@@ -5,14 +5,17 @@ const loading = keyframes`
   0% {
     opacity:1;
   }
-  30% {
+  25% {
     opacity:0.2;
   }
-  60% {
+  50% {
     opacity:1;
   }
-  100% {
+  75%{
     opacity:0.2;
+  }
+ 100%{
+    opacity:1;
   }
 `;
 
@@ -25,7 +28,7 @@ export const LoadingBgDivStyle = styled.div`
   position: absolute;
   display: flex;
   width: 200px;
-  padding: 0 5%;
+  padding: 0 20px;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
@@ -34,7 +37,10 @@ export const LoadingBgDivStyle = styled.div`
 `;
 
 export const LogoLeafStyle = styled.img`
-  width: 30%;
+  width: 45px;
   margin-top: -48px;
   animation: 1.5s ${loading} ease-in-out infinite;
+  & + img {
+    margin-left: 11px;
+  }
 `;


### PR DESCRIPTION
### 무엇을 위한 PR인가요?
- [x] 스타일 : Loading 이미지 깨짐 문제 해결


### 전달사항
- LoadingStyle.jsx에서 이미지 사이즈 관련 코드를 `%`가 아닌 고정 `px`로 변경하여 문제를 해결했습니다.
- 깜박거리는 애니메이션을 조금 더 자연스럽게 표현하기 위해 keyframes의 `%`를 수정했습니다.

### 변경사항 및 이유
- 이유 : 위의 전달사항과 동일


### 작업 내역
- 작업 내역 : src/pages/Loading/LoadingStyle.jsx


### 기대 결과
- 로딩 중 나타나는 이미지가 화면비와 상관없이 동일하게 출력됩니다.

### Issue Number
close : #225 
