### PR TITLE
LightHouse 점수 개선을 위한 코드 수정

### DIFF
--- a/src/components/Blank/Blank.jsx
+++ b/src/components/Blank/Blank.jsx
@@ -5,7 +5,7 @@ import { BlankImgStyle, BlankTextStyle } from './BlankStyle';
 export default function Blank({ src, width, text, children, go, onClick }) {
   return (
     <div>
-      <BlankImgStyle src={src} width={width} />
+      <BlankImgStyle src={src} width={width} alt="" />
       <BlankTextStyle>{text}</BlankTextStyle>
       <Button size="m" variant="abled" go={go} onClick={onClick}>
         {children}

--- a/src/components/CommentsIcon/CommentIcon.jsx
+++ b/src/components/CommentsIcon/CommentIcon.jsx
@@ -4,7 +4,7 @@ import { CommentWrapStyle, CommentbtnStyle } from './CommentIconStyle';
 export default function CommentIcon({ commentCount }) {
   return (
     <CommentWrapStyle>
-      <CommentbtnStyle />
+      <CommentbtnStyle aria-label="댓글 및 상세 게시글 보기" />
       <span>{commentCount}</span>
     </CommentWrapStyle>
   );

--- a/src/components/MetaDatas/MetaDatas.jsx
+++ b/src/components/MetaDatas/MetaDatas.jsx
@@ -16,6 +16,12 @@ export default function MetaDatas({ title, pageURL, desc }) {
       <meta property="og:image" content="%PUBLIC_URL%/full-logo.png" />
       <meta property="og:site_name" content={`${title} - 풍년마켓`} />
       <meta property="og:description" content={desc} />
+      <meta
+        name="description"
+        lang="ko"
+        content="주말농장 농산물 직거래 플랫폼 풍년마켓"
+      />
+      <meta name="author" content="프로젝트 팀 십전백기"></meta>
     </Helmet>
   );
 }

--- a/src/components/PostCard/PostCard.jsx
+++ b/src/components/PostCard/PostCard.jsx
@@ -77,7 +77,7 @@ export default function PostCard({ post, author }) {
               image={author.image}
             />
           </Link>
-          <PostIconMoreStyle onClick={modalUp} />
+          <PostIconMoreStyle onClick={modalUp} aria-label="더보기" />
         </PostProfileDivStyle>
         <PostDivStyle>
           <PostContentsStyle>{post.content}</PostContentsStyle>

--- a/src/components/Product/ProductStyle.jsx
+++ b/src/components/Product/ProductStyle.jsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { Ellipsis } from '../../styles/GlobalStyles';
 
-export const ProductWrap = styled.article`
+export const ProductWrap = styled.li`
   width: 140px;
 `;
 

--- a/src/components/common/Nav/Nav.jsx
+++ b/src/components/common/Nav/Nav.jsx
@@ -55,7 +55,10 @@ export default function Nav() {
           <NavLinkStyle to="/home">
             {({ isActive }) => (
               <>
-                <StyledImg src={isActive ? IconHome.fill : IconHome.default} />
+                <StyledImg
+                  src={isActive ? IconHome.fill : IconHome.default}
+                  alt=""
+                />
                 <p>홈</p>
               </>
             )}
@@ -67,6 +70,7 @@ export default function Nav() {
               <>
                 <StyledImg
                   src={isActive ? IconMessage.fill : IconMessage.default}
+                  alt=""
                 />
                 <p>채팅</p>
               </>
@@ -77,7 +81,10 @@ export default function Nav() {
           <NavLinkStyle to="/post_upload">
             {({ isActive }) => (
               <>
-                <StyledImg src={isActive ? IconEdit.fill : IconEdit.default} />
+                <StyledImg
+                  src={isActive ? IconEdit.fill : IconEdit.default}
+                  alt=""
+                />
                 <p>게시글 작성</p>
               </>
             )}
@@ -87,7 +94,10 @@ export default function Nav() {
           <NavLinkStyle to={`/my_profile/${account}`}>
             {({ isActive }) => (
               <>
-                <StyledImg src={isActive ? IconUser.fill : IconUser.default} />
+                <StyledImg
+                  src={isActive ? IconUser.fill : IconUser.default}
+                  alt=""
+                />
                 <p>프로필</p>
               </>
             )}


### PR DESCRIPTION
### 무엇을 위한 PR인가요?
- [x] 기타 : LightHouse 점수 개선을 위한 코드 수정


### 전달사항
- 해당 PR은 가장 콘텐츠가 많은 Home과 MyProfile 페이지를 기준으로 작업되었습니다.
- 성능과 관련해서는 이미지와 관련된 이슈가 차지하는게 큰 것으로 보여집니다. 해당 부분을 개선해볼 수 있도록 같이 고민해보면 좋을거 같습니다!


### 변경사항 및 이유
- 코드 수정 전 Light house 점수는 다음과 같았습니다.
<img width="599" alt="스크린샷 2023-02-13 오후 11 17 31" src="https://user-images.githubusercontent.com/94048689/218490468-9cd4e882-8566-4d02-94c5-94d1523ba14e.png">
<img width="618" alt="스크린샷 2023-02-13 오후 11 16 37" src="https://user-images.githubusercontent.com/94048689/218490487-902f5f85-8b1b-42b5-8e03-6b3ce5a0c069.png">

- 접근성과 검색엔진 최적화에서 요구되는 사항은 다음과 같았습니다.
<img width="760" alt="스크린샷 2023-02-13 오후 11 16 52" src="https://user-images.githubusercontent.com/94048689/218490711-bf74f560-4a5e-4fac-aa81-c7f155f6a598.png">
<img width="760" alt="스크린샷 2023-02-13 오후 11 17 00" src="https://user-images.githubusercontent.com/94048689/218490721-b734c466-b3b4-40a6-801b-c799c9593a9e.png">

- 이를 토대로 다음 3가지 부분을 수정했습니다
1. `img` 태그에서 `alt` 코드가 누락된 부분을 찾아 추가해주었습니다.
2. 설명이 충분치 않은 `button`에는 `aria-label`로 해당 버튼의 목적을 추가해주었습니다.
3. `meta` 태그로 `description`과 `author`를 추가해주었습니다. 

- 또, product에서 시멘틱하지 않은 태그를 발견하여 수정해주었습니다. (ul 하위에 article이 삽입되어있어 해당 부분을 li로 수정)

- 수정 후 Light house 점수는 다음과 같습니다
<img width="610" alt="스크린샷 2023-02-13 오후 10 53 04" src="https://user-images.githubusercontent.com/94048689/218492571-c934c23f-59d8-4912-a202-775b5191af64.png">
<img width="608" alt="스크린샷 2023-02-13 오후 10 52 38" src="https://user-images.githubusercontent.com/94048689/218492583-9dd6cdd2-b07c-4869-a0a0-edeba43d1556.png">



### 작업 내역
- 작업 내역 : Files changed 참조 부탁드립니다.


### 기대 결과
-  변경사항 및 이유 참조


### Issue Number
close : #229 
